### PR TITLE
Recommend a new deploy command line 

### DIFF
--- a/deploy.md
+++ b/deploy.md
@@ -3,6 +3,4 @@ password CX3@yatai
 
 cd /usr/local/
 
-yarn build && tar -cvf cx.tar dist/ && scp cx.tar root@47.97.168.223:/usr/local/
-
-tar -xvf cx.tar && rm -rf cx && mkdir cx && mv dist/* cx/ && nginx -s reload
+yarn build && cd dist && tar -c * | ssh 47.97.168.223 -l root "cd /usr/local/ && rm -rf cx && mkdir cx && cd cx && tar -xv && nginx -s reload"


### PR DESCRIPTION
Use pipe with tar(1) and ssh(1) to deploy files without need of scp(1).